### PR TITLE
Merging DebConf changes

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -45,8 +45,9 @@ forums, is subject to this code of conduct and thus may not contain:
 Presenters are asked to avoid language which is not appropriate for an
 all-ages audience as much as possible.
 
-If the content of the presentation requires including language that could
-be considered offensive, this should be pointed out in advance, at the
+If the subject matter of the presentation cannot be presented
+adequately without including language that could be considered
+offensive, this should be pointed out in advance, at the
 beginning of the talk and in the schedule.
 
 If presenters are unsure whether their material is suitable, they are


### PR DESCRIPTION
In the spirit of keeping the Debian delta as small as possible, I am submitting upstream a patch from DebConf (who based their code of conduct for their 2014 conference on the Linux Australia template).

Credit for this patch goes to Margarita Manterola.

See the [original patch](http://lists.debconf.org/lurker/message/20140904.221307.3c4b2a0c.en.html)  and the [discussion](http://lists.debconf.org/lurker/message/20140904.031111.11095803.en.html).
