### PR TITLE
Update code_of_conduct.md to remove "non-consensual licking" as a cited example of problem behaviour

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -89,7 +89,6 @@ are not appropriate:
 * stalking or following;
 * unwanted photography or recording;
 * sustained disruption of talks or other events;
-* non-consensual licking;
 * intoxication at an event venue;
 * inappropriate physical contact;
 * unwelcome sexual attention;


### PR DESCRIPTION
This came up during Ghosts, I was surprised to find this line still there.