### PR TITLE
Removes 'non-consensual licking' as a specific example

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -89,7 +89,6 @@ are not appropriate:
 * stalking or following;
 * unwanted photography or recording;
 * sustained disruption of talks or other events;
-* non-consensual licking;
 * intoxication at an event venue;
 * inappropriate physical contact;
 * unwelcome sexual attention;


### PR DESCRIPTION
I have spent a non-negligible amount of time defending the inclusion of this precise line in the Code of Conduct. It clearly falls under "inappropriate physical contact", and it would be much much easier to point to that.