### PR TITLE
markdown typography

### DIFF
--- a/mail-list-policy.md
+++ b/mail-list-policy.md
@@ -1,15 +1,22 @@
-#﻿Mailing list policy
-##Definitions
-###Council
+Mailing list policy
+===================
+
+Definitions
+-----------
+
+### Council
 The member-elected governing body of Linux Australia. Council has the authority to create, moderate and delete lists and list postings for all mailing lists it hosts, and the authority to delegate these actions to Moderators. Council is responsible for the creation, promulgation and enforcement of this policy.
 
-###Moderator
+### Moderator
 A natural person with delegated authority to create, moderate, and delete lists and list postings in line with this policy. A moderator is appointed at the pleasure of Council and may be changed at Council's discretion. Council authorises Moderators to act without seeking prior approval from Council and trusts them to exercise their duties in a responsible and professional manner.
 
 
-###List member
+### List member
 A natural person, who may or may not be a member of Linux Australia, who has voluntarily or as part of their membership of Linux Australia, been subscribed to one or more mailing lists hosted by Linux Australia. To continue being a list member, the list member accepts to be bound by this policy.
-##Introduction and rationale
+
+Introduction and rationale
+--------------------------
+
 This document outlines policy in relation to acceptable use of mailing lists hosted by Linux Australia. This policy exists so that;
 
 * List participants have a clear understanding of what is acceptable
@@ -19,7 +26,8 @@ This document outlines policy in relation to acceptable use of mailing lists hos
 
 This policy therefore articulates boundaries around acceptable use of mailing lists hosted by Linux Australia, and defines appropriate actions and recourse where those boundaries are transgressed.
 
-##Policy
+Policy
+------
 
 1. Creation of lists
 


### PR DESCRIPTION
The conversion of the mail-list-policy.md file from ASCII text to markdown introduced a few, probably unintended errors in the typesetting.  These changes address that.  No policy text or content is modified.

* Fixed the header lines and made the top and second level headers consistent with the other documents (i.e. underlined with the equals sign (U+003D) or the hyphen-minus sign (U+002D).
* Stripped out the carriage return control characters from the end of each line (which is why it looks like there are lots of changes when really none of the text has been modified at all).


<hr />

**NOTE:** This contribution is made in accordance with my [project participation policy](https://gitlab.com/Hasimir/project-participation-policy/tree/master/conduct).  Acceptance of this pull request requires acceptance of this policy.  If your project cannot comply with this policy or is opposed to the policy, then please reject the pull request with a comment stating either that your policies prevent accepting it or that your project is actively opposed to the policy.