### PR TITLE
Add Objects

### DIFF
--- a/constitution.txt
+++ b/constitution.txt
@@ -605,7 +605,7 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
   (a) to facilitate the communication of information relating to inventions, results, techniques, and governance of open source;
 
-  (b) to support open source projects and the creators of open source ;
+   (b) to support open source projects and the creators of open source;
 
   (c) to support and promote the adoption of open source;
 

--- a/constitution.txt
+++ b/constitution.txt
@@ -619,4 +619,4 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
 (3) The Organisation must manage payments and gifts to the Organisation and ensure that they are used to further the stated objects of the Organisation.
 
-(4) In the event of the Organisation being wound up its assets of the must go to a charitable entity whose objectives aren’t inconsistent with the stated objects of the Organisation.
+(4) In the event of the Organisation being wound up, its assets must go to a charitable entity whose objectives aren’t inconsistent with the stated objects of the Organisation.

--- a/constitution.txt
+++ b/constitution.txt
@@ -615,7 +615,7 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
   (f) to create a network for related local and online open source communities.
 
-(2) The Organisation must pursue charitable purposes only and must apply its income in promoting those purposes.
+(2) The association must pursue charitable purposes only and must apply its income in promoting those purposes.
 
 (3) The Organisation must manage payments and gifts to the Organisation and ensure that they are used to further the stated objects of the Organisation.
 

--- a/constitution.txt
+++ b/constitution.txt
@@ -598,3 +598,25 @@ The financial year of the association is:
 
 Note: Schedule 1 of the Act provides that an association’s constitution is to address the association’s financial year.
 
+
+43. Objects of the Organisation
+
+(1) The objects for which the Organisation is established are:
+
+  (a) to provide  facilitate communication of information relating to inventions, results, techniques, and governance of open source;
+
+  (b) to support the creators of open source and open source projects;
+
+  (c) to support and promote the adoption of open source;
+
+  (d) to support and promote awareness and understanding of open source;
+
+  (e) to conduct open source advocacy with the government, business and civil society;
+
+  (f) to create a network for related local and online open source communities.
+
+(2) The Organisation must pursue charitable purposes only and must apply its income in promoting those purposes.
+
+(3) The Organisation must manage payments and gifts to the Organisation and ensure that they are used to further the stated objects of the Organisation.
+
+(4) In the event of the Organisation being wound up its assets of the must go to a charitable entity whose objectives aren’t inconsistent with the stated objects of the Organisation.

--- a/constitution.txt
+++ b/constitution.txt
@@ -617,6 +617,6 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
 (2) The association must pursue charitable purposes only and must apply its income in promoting those purposes.
 
-(3) The Organisation must manage payments and gifts to the Organisation and ensure that they are used to further the stated objects of the Organisation.
+(3) The association must manage payments and gifts to the association and ensure that they are used to further the stated objects of the association.
 
 (4) In the event of the Organisation being wound up, its assets must go to a charitable entity whose objectives aren’t inconsistent with the stated objects of the Organisation.

--- a/constitution.txt
+++ b/constitution.txt
@@ -619,4 +619,4 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
 (3) The association must manage payments and gifts to the association and ensure that they are used to further the stated objects of the association.
 
-(4) In the event of the Organisation being wound up, its assets must go to a charitable entity whose objectives aren’t inconsistent with the stated objects of the Organisation.
+(4) In the event of the association being wound up, its assets must go to a charitable entity whose objectives aren’t inconsistent with the stated objects of the association.

--- a/constitution.txt
+++ b/constitution.txt
@@ -605,7 +605,7 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
   (a) to facilitate the communication of information relating to inventions, results, techniques, and governance of open source;
 
-   (b) to support open source projects and the creators of open source;
+    (b) to support open source projects and the contributors to open source;
 
   (c) to support and promote the adoption of open source;
 

--- a/constitution.txt
+++ b/constitution.txt
@@ -605,7 +605,7 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
   (a) to facilitate the communication of information relating to inventions, results, techniques, and governance of open source;
 
-  (b) to support the creators of open source and open source projects;
+  (b) to support open source projects and the creators of open source ;
 
   (c) to support and promote the adoption of open source;
 

--- a/constitution.txt
+++ b/constitution.txt
@@ -605,7 +605,7 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
   (a) to facilitate the communication of information relating to inventions, results, techniques, and governance of open source;
 
-    (b) to support open source projects and the contributors to open source;
+  (b) to support open source projects and the contributors to open source;
 
   (c) to support and promote the adoption of open source;
 

--- a/constitution.txt
+++ b/constitution.txt
@@ -599,7 +599,7 @@ The financial year of the association is:
 Note: Schedule 1 of the Act provides that an association’s constitution is to address the association’s financial year.
 
 
-43. Objects of the Organisation
+43. Objects of the association
 
 (1) The objects for which the Organisation is established are:
 

--- a/constitution.txt
+++ b/constitution.txt
@@ -601,7 +601,7 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
 43. Objects of the association
 
-(1) The objects for which the Organisation is established are:
+(1) The objects for which the association is established are:
 
   (a) to facilitate the communication of information relating to inventions, results, techniques, and governance of open source;
 

--- a/constitution.txt
+++ b/constitution.txt
@@ -603,7 +603,7 @@ Note: Schedule 1 of the Act provides that an association’s constitution is to 
 
 (1) The objects for which the Organisation is established are:
 
-  (a) to provide  facilitate communication of information relating to inventions, results, techniques, and governance of open source;
+  (a) to facilitate the communication of information relating to inventions, results, techniques, and governance of open source;
 
   (b) to support the creators of open source and open source projects;
 


### PR DESCRIPTION
Add "Objects of the Association" to the constitution. The Australian Charities an Not for Profits Commission requires a statement of objects in the constitution before they will process an application to become a charity.