### PR TITLE
Update list of attributes in code of conduct

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -83,9 +83,9 @@ any intimidation, harassment, or abusive or discriminatory behaviour.
 Here are some examples of behaviours that have occurred at past events which
 are not appropriate:
 
-* offensive verbal or written remarks related but not limited to
-  gender, sex, sexual orientation, disability, physical appearance, body
-  size, race or religion;
+* offensive verbal or written remarks related but not limited to age,
+  gender, gender identity, gender expression, sex characteristics, sexual
+  orientation, disability, physical appearance, body size, race or religion;
 * sexual or violent images in public spaces (including presentation slides);
 * deliberate intimidation;
 * stalking or following;
@@ -96,9 +96,9 @@ are not appropriate:
 * unwelcome sexual attention;
 * sexist, racist, or other exclusionary jokes;
 * unwarranted exclusion from conference or related events based on
-  attributes such as (but not limited to) age, gender, sex, sexual
-  orientation, disability, physical appearance, body size, race,
-  religion;
+  attributes such as (but not limited to) age, gender, gender identity, gender
+  expression, sex characteristics, sexual orientation, disability, physical
+  appearance, body size, race, religion;
 
 We want everyone to have a good time at our events.
 


### PR DESCRIPTION
This PR proposes the following changes to the Linux Australia Code of Conduct, focused around the lists of attributes in the _What does that mean for me?_ section.

- Adds "age" to the first list (of offensive verbal or written remarks). It is already in the second list (unwarranted exclusion), so my assumption is that its omission in the first is an oversight.
- Adds "gender identity" and "gender expression". This makes it more clear that discriminatory behaviour towards transgender, non-binary, and gender non-conforming people is not acceptable. As far as I'm aware, this has been the existing position of safety teams at past LCAs and PyCons AU; this makes this more clear.
- Adds "sex characteristics". This makes it more clear that discriminatory behaviour towards people with intersex variations is not acceptable. (["Sex characteristics" is the phrase that IHRA considers preferable in this context](https://ihra.org.au/discrimination/), insofar as I can tell.)
- Removes "sex". This is unclear, and probably made redundant by the other additions here; it could refer to discrimination against e.g. women (already covered by "gender"), trans and non-binary people (covered by the addition of "gender identity"), or intersex people (covered by the addition of "sex characteristics").