### PR TITLE
Remove TLDR from Code of Conduct

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -4,10 +4,6 @@ Code of Conduct (template)
 This code of conduct applies to our community and serves as a template to our
 conferences.
 
-TL;DR
------
-Be excellent to each other.
-
 All Linux Australia events are intended to be environments where delegates 
 can get together to learn from and be inspired by each other about all things 
 Free and Open Source. Linux Australia aims to foster an atmosphere of trust, 


### PR DESCRIPTION
This PR proposes removing the TLDR "Be excellent to each other." from the Code of Conduct. 


PyCon AU as been running without this summary for a number of years (since [2018](https://2018.pycon-au.org/conduct/), see also [this search](https://github.com/search?q=org%3Apyconau+%22be+excellent%22&type=code) for the term in the PyCon AU website repos). 

We have felt that the summary's removal makes the Code of Conduct stronger, and less likely to be skimmed/skipped reading based on having a summary sentence that is a quote from a 30+ year old movie, and may be lost in translation without context about what "be excellent" means and who "each other" are.


See also [the argument last time this was suggested (now 5+ years ago)](https://github.com/linuxaustralia/constitution_and_policies/pull/24#issuecomment-270048474)

See also [a more detailed argument](https://web.archive.org/web/20171122193117/https://plus.google.com/+HannahGrimm/posts/5517czLTefa) removing this summary from another group. 