### PR TITLE
Grant guidelines: try to clarify expectations for hardware purchases.

### DIFF
--- a/guidelines_for_grant_submissions.md
+++ b/guidelines_for_grant_submissions.md
@@ -33,7 +33,7 @@ In contrast, proposals which are unlikely to be accepted include:
 
 For grants that include the funding of hardware purchases to support Open Source software development:
 
-* The grant application should include a description of what the project aims to achieve.  For example:
+* The grant application should include a description of what the project aims to achieve with the funded hardware.  For example:
     - Support for this hardware is committed to the upstream project repository.
     - A sustainable community of developers is formed to continue development and support of the hardware.
     - An individual takes an active role in the development of Open Source support for the hardware, which would have otherwise been impossible due to the cost of the hardware.

--- a/guidelines_for_grant_submissions.md
+++ b/guidelines_for_grant_submissions.md
@@ -31,4 +31,15 @@ In contrast, proposals which are unlikely to be accepted include:
 * Development of hardware or software which will not be released under an open licence
 * Applications which lack justification and explanation of the amount requested
 
+For grants that include the funding of hardware purchases to support Open Source software development:
+
+* The grant application should include a description of what the project aims to achieve.  For example:
+    - Support for this hardware is committed to the upstream project repository.
+    - A sustainable community of developers is formed to continue development and support of the hardware.
+    - An individual takes an active role in the development of Open Source support for the hardware, which would have otherwise been impossible due to the cost of the hardware.
+
+* An individual or group may receive at most one grant of this nature per grant cycle.
+
+* In the project's final report provided to Linux Australia, include a review of what went well and what did not. If the project’s objectives were not met, explain what might have helped the project achieve more.  If applicable, describe any follow up activities which could build on the progress made and how others might be able to assist to provide additional value for the broader community.
+
 The Linux Australia Council welcomes the opportunity to work with the authors of grant applications if assistance is needed to transform ideas into a viable proposal.

--- a/guidelines_for_grant_submissions.md
+++ b/guidelines_for_grant_submissions.md
@@ -40,6 +40,6 @@ For grants that include the funding of hardware purchases to support Open Source
 
 * An individual or group may receive at most one grant of this nature per grant cycle.
 
-* In the project's final report provided to Linux Australia, include a review of what went well and what did not. If the project’s objectives were not met, explain what might have helped the project achieve more.  If applicable, describe any follow up activities which could build on the progress made and how others might be able to assist to provide additional value for the broader community.
+* In the project's final report provided to Linux Australia, include a review of what went well and what did not.  If the project’s objectives were not met, explain what might have helped the project achieve more.  If applicable, describe any follow up activities which could build on the progress made and how others might be able to assist to provide additional value for the broader community.  If the grant included funding for hardware, explain the future plans for that hardware.
 
 The Linux Australia Council welcomes the opportunity to work with the authors of grant applications if assistance is needed to transform ideas into a viable proposal.


### PR DESCRIPTION
Over recent years there has been an increased interest in using Linux Australia grants to fund hardware purchases in support of software development activities.  When interfacing with hardware, software development can often take unexpected turns which makes it difficult to determine whether the exercise is considered a success at its conclusion. To address this challenge and to ensure equitable access to the grants across the Linux Australia membership, it is proposed by the Linux Australia Council that the information in this commit be added to the grant guidelines.

This information will make it easier for the Linux Australia Council and the wider membership to evaluate the effectiveness of these grants.  Where applicable, it can also help determine whether additional future support for the project, group or activity represents good value for Linux Australia, its members and the Open Source community in general.